### PR TITLE
 fix(nvim): adjust highlight range from first letter

### DIFF
--- a/plugin/skkeleton_henkan_highlight.vim
+++ b/plugin/skkeleton_henkan_highlight.vim
@@ -53,7 +53,7 @@ function! s:enable_highlight() abort
   let start = min([s:henkan_pos[2], col])
   let end = max([s:henkan_pos[2], col])
   if has('nvim')
-    call nvim_buf_set_extmark(0, s:namespace, line - 1, start - 1, #{
+    call nvim_buf_set_extmark(0, s:namespace, line - 1, start - 2, #{
           \   end_col: end - 1,
           \   hl_group: s:highlight_name,
           \ })


### PR DESCRIPTION
Given a letter inserted at the first column in Insert mode,

- Since `col('.')` is 1-indexed, considering zero-width positions, `col('.')` returns `2` when cursor is _after_ the character. (`col('.')` returns `1` when cursor is _before_ the character.)
- On the other hand, `nvim_buf_set_extmark`, where `{col}` is 0-indexed, but only considering letter-printable positions, should assign `0` at `{col}` to highlight the first character there, where `col('.')` returns `2` as described above.

Therefore, `{col}` for `nvim_buf_set_extmark` should be `col('.') - 2` to determine the highlight beginning column by cursor position in Insert mode.